### PR TITLE
Clarify field in getAuctionStatus method

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -68,7 +68,7 @@ class Tasks {
           mintable,
 
           auctionSupply,
-          auctionStartTime,
+          nextAuctionStartTime,
 
           blockInfo,
           totalSupply
@@ -82,7 +82,7 @@ class Tasks {
             tokenSold: mintable / 1e18,
             tokenCirculation: totalSupply / 1e18,
             tokenRemaining: totalSupply / 1e18 - mintable / 1e18,
-            auctionStartTime: parseInt(nextAuction._startTime) - blockInfo.timestamp,
+            nextAuctionStartTime: parseInt(nextAuction._startTime, 10),
 
             genesisTime
           }


### PR DESCRIPTION
Field auctionStartTime contained the difference (in seconds) between
the current block time and the next auction time, which was somewhat
misleading and less useful for knowing the real auction time.

The field was renamed to nextAuctionStartTime and now contains the
timestamp for the next auction.