### PR TITLE
Add injection check middleware

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -82,6 +82,19 @@ class Server {
       next(null)
     }
 
+    const injectionChecker = (req, res, next) => {
+      delete req.query.$where
+
+      const HTML_REGEX = /(<([^>]+)>)/ig
+      Object.keys(req.query).forEach(k => {
+        if (k.match(HTML_REGEX)) {
+          return res.send(400)
+        }
+      })
+
+      next(null)
+    }
+
     this.logger.verbose('Attaching middleware to express app')
 
     this.expressApp.use(createReqLogger)
@@ -95,6 +108,8 @@ class Server {
         maxResultsLimit: this.config.server.maxResultsLimit
       })
     )
+
+    this.expressApp.use(injectionChecker)
 
     this.logger.verbose('Middleware attached')
   }


### PR DESCRIPTION
- Prevents $where as the query string
- Rejects query strings with html tags