### PR TITLE
Return more datapoints by default

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -15,7 +15,7 @@
   },
   "history": {
     "auctionOversampling": 10,
-    "maxDataPoints": 250
+    "maxDataPoints": 500
   },
   "logger": {
     "Console": {


### PR DESCRIPTION
For 7 days auction data, the number of required points is ~500.