### PR TITLE
Dockerize the service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.eslintcache
+.nyc_output
+config/local.json
+coverage
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    git
+
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get install -y nodejs
+
+WORKDIR /usr/src/api
+COPY package.json .
+COPY package-lock.json .
+COPY patches patches
+RUN npm install
+COPY . .
+
+CMD ["npm", "start"]
+
+EXPOSE 3002

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /usr/src/api
 COPY package.json .
 COPY package-lock.json .
 COPY patches patches
-RUN npm install
+RUN npm install --unsafe-perm
 COPY . .
 
 CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ The following environment variables are needed for the API to work:
 
   I.E. `ws://node.metronome.io:8546`.
 
-* `ETH_CHAIN`: The name of the Ethereum chain (`ropsten` or `mainnet`).
+* `ETH_CHAIN`: The name of the Ethereum chain.
 
-  I.E. `mainnet`.
+  I.E. `ropsten` or `mainnet`.
 
 * `MONGO_URL`: The Mongo instance URL.
 
@@ -44,7 +44,7 @@ The following environment variables are needed for the API to work:
 
 * `MONGO_DB_NAME`: The Mongo database name.
 
-  I.E. `metronome`.
+  I.E. `metronome-api`.
 
 ## Dev Setup
 

--- a/config/default.json
+++ b/config/default.json
@@ -3,9 +3,9 @@
     "origin": "*"
   },
   "eth": {
-    "chain": "mainnet",
+    "chain": "ropsten",
     "enabled": true,
-    "exportStartBlock": 0,
+    "exportStartBlock": 3399250,
     "nodeTiemout": 30000,
     "reconnectInterval": 3000,
     "founderTokens": "2000000000000000000000000",
@@ -34,7 +34,7 @@
   },
   "mongo": {
     "url": "mongodb://localhost",
-    "dbName": "metronome"
+    "dbName": "metronome-api"
   },
   "newRelic": {},
   "port": 3002,

--- a/lib/metronome/status-collector.js
+++ b/lib/metronome/status-collector.js
@@ -11,13 +11,13 @@ const logger = require('../../logger')
 const web3 = new Web3(
   new Web3.providers.WebsocketProvider(webSocketUrl, { autoReconnect: true })
 )
-const { auctions, autonomousConverter } = new MetronomeContracts(web3, chain)
+const { Auctions, AutonomousConverter } = new MetronomeContracts(web3, chain)
 
-const getHeartbeat = () => auctions.methods.heartbeat().call()
+const getHeartbeat = () => Auctions.methods.heartbeat().call()
 const getConverterStatus = () => promiseAllProps({
-  availableMet: autonomousConverter.methods.getMetBalance().call(),
-  availableEth: autonomousConverter.methods.getEthBalance().call(),
-  currentConverterPrice: autonomousConverter.methods.getEthForMetResult('1000000000000000000').call()
+  availableMet: AutonomousConverter.methods.getMetBalance().call(),
+  availableEth: AutonomousConverter.methods.getEthBalance().call(),
+  currentConverterPrice: AutonomousConverter.methods.getEthForMetResult('1000000000000000000').call()
 })
 
 function onData (header) {

--- a/lib/metronome/status.js
+++ b/lib/metronome/status.js
@@ -58,9 +58,9 @@ class Status {
   getStatus () {
     this.logger.verbose('Fetching status')
 
-    const token = this.metronomeContracts.metToken.methods
-    const auctions = this.metronomeContracts.auctions.methods
-    const converter = this.metronomeContracts.autonomousConverter.methods
+    const token = this.metronomeContracts.METToken.methods
+    const auctions = this.metronomeContracts.Auctions.methods
+    const converter = this.metronomeContracts.AutonomousConverter.methods
 
     const calls = {
       currentAuction: auctions.currentAuction().call().catch(() => 0),

--- a/lib/metronome/token-exporter.js
+++ b/lib/metronome/token-exporter.js
@@ -7,7 +7,7 @@ class TokenExporter {
     this.config = config
     this.db = db
     this.logger = logger
-    this.metToken = ethApi.metronomeContracts.metToken
+    this.metToken = ethApi.metronomeContracts.METToken
     this.web3 = ethApi.web3
     this.socket = socket
 

--- a/lib/stats-db.js
+++ b/lib/stats-db.js
@@ -132,7 +132,7 @@ function sampleAuctionArray (array) {
   return result
 }
 
-function getAllData (from, to, oversample) {
+function getAllData (from, to, oversample = 1) {
   const timeWindow = Math.round((to - from) / oversample)
 
   logger.debug('Retrieving data (%ds)', timeWindow)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7297,9 +7297,9 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "metronome-contracts": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/metronome-contracts/-/metronome-contracts-1.4.1.tgz",
-      "integrity": "sha512-8Yp9Ye1AiMiowJ/0pPDG+zqc3rLeyOMM6E6xxLo6TmyKtfBgk5kdJr6QAHEnPky+QjajmVUhVAWwtZpwYyEcMg=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/metronome-contracts/-/metronome-contracts-2.3.0.tgz",
+      "integrity": "sha512-ZsYCCu+6MhRD5E9cK25YN9Zeih+g+omVh19Le29nbu8TUCV2f3R1G311w+/fp6wDGV9ZvyiC3gif9AdpImTarw=="
     },
     "micromatch": {
       "version": "3.1.10",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "config": "node -e \"console.log(require('config'))\"",
     "dev": "nodemon server",
     "debug": "node --inspect ./bin/met-api",
+    "docker:build": "docker build -t metronome-api .",
     "lint": "eslint . --ext .js",
     "lint:fix": "eslint . --fix .js",
     "test": "jest --forceExit -i",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "express": "4.16.4",
     "express-rest-api": "0.1.0",
     "figlet": "1.2.1",
-    "metronome-contracts": "1.4.1",
+    "metronome-contracts": "2.3.0",
     "mongoose": "5.4.17",
     "mongoose-count-and-find": "1.0.0",
     "mongoose-cu-timestamps": "1.0.0",

--- a/test/lib.metronome.status.spec.js
+++ b/test/lib.metronome.status.spec.js
@@ -28,7 +28,7 @@ const heartbeatMock = {
 }
 
 const metronomeContractsMock = {
-  auctions: {
+  Auctions: {
     methods: {
       auctionStartTime: () => ({ call: () => Promise.resolve() }),
       auctionSupply: () => ({ call: () => Promise.resolve() }),
@@ -43,13 +43,13 @@ const metronomeContractsMock = {
     }
   },
 
-  metToken: {
+  METToken: {
     methods: {
       totalSupply: () => ({ call: () => Promise.resolve() })
     }
   },
 
-  autonomousConverter: {
+  AutonomousConverter: {
     methods: {
       getMetBalance: () => ({ call: () => Promise.resolve() }),
       getEthBalance: () => ({ call: () => Promise.resolve() }),


### PR DESCRIPTION
Add definitions and script to create a docker image of the API through `npm run docker:build` to allow easier building of the dev and test environments.

In addition, fix a small issue in a history route handler, fix default values and update docs.