### PR TITLE
Replaced flat() with concat()

### DIFF
--- a/lib/metronome.js
+++ b/lib/metronome.js
@@ -49,7 +49,7 @@ class Metronome {
         toBlock = endBlock
       }
     }
-    return events.flat(Infinity)
+    return [].concat(...events)
   }
 
   saveBestBlock(e) {


### PR DESCRIPTION
To support Node v10, flat() method call is replaced with use of concat(). Fixes issue #100 